### PR TITLE
add gitignore fvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+.fvm
 
 # Web related
 lib/generated_plugin_registrant.dart


### PR DESCRIPTION
## やったこと
`.fvm` をgitignoreに追加しました

すでにバージョン管理ツールとしては tool-versions が導入されていますが、fvmとの共存が出来なかったのでローカルで実行する時にだけfvmで管理したく、Gitに含めないようにしました。

（ハンズオンの時にバージョン管理ツールには触れないようにしたいな、とは個人的には思っています。）

### 参考
https://fvm.app/  
https://zenn.dev/riscait/articles/asdf-flutter