### PR TITLE
TODOの記述の削除

### DIFF
--- a/docs/outline/2_graphql-client.md
+++ b/docs/outline/2_graphql-client.md
@@ -98,12 +98,6 @@ GraphQL クライアントに graphql_flutter の使用が決まれば、実際�
 
 [@preview](https://docs.hivedb.dev/)
 
-
-
-TBD (Hive の説明)
-
-
-
 GraphQL クライアントのキャッシュに Hive を使用しているため、それらの初期化を行います。
 
 ```dart [lib/main.dart]


### PR DESCRIPTION
- Hiveの初期化の説明が加筆されているのでTODOの記述に関しては削除しても良さそうに思いました。
- 本MRとは別件ですが [公開ドキュメント側](https://deploy-preview-35--flutterkaigi-2022-workshop.netlify.app/outline/2_graphql-client.html)では途中の状態で公開されているように見えたのでデプロイ漏れ...ですかね？  
> TBD (Hive の説明)
> GraphQL クライアントのキャッシュに Hive を使用しているため、それらの初期化を行います。

の記述で止まっているようでした。